### PR TITLE
Fix goodEnoughQuicklyOrNothingObservable sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Observable<Location> goodEnoughQuicklyOrNothingObservable = locationProvider.get
                     return location.getAccuracy() < SUFFICIENT_ACCURACY;
                 }
             })
-            .timeout(LOCATION_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS, Observable.from((Location) null), AndroidSchedulers.mainThread())
+            .timeout(LOCATION_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS, Observable.just((Location) null), AndroidSchedulers.mainThread())
             .first()
             .observeOn(AndroidSchedulers.mainThread());
 


### PR DESCRIPTION
I get a compile error from `Observable.from((Location) null)`

I fixed it by changing to `Observable.just((Location) null)` which I think does what you intended.