### PR TITLE
LastKnownLocationObservable violates Observable contract

### DIFF
--- a/android-reactive-location/src/main/java/pl/charmas/android/reactivelocation/observables/location/LastKnownLocationObservable.java
+++ b/android-reactive-location/src/main/java/pl/charmas/android/reactivelocation/observables/location/LastKnownLocationObservable.java
@@ -22,7 +22,10 @@ public class LastKnownLocationObservable extends BaseLocationObservable<Location
 
     @Override
     protected void onGoogleApiClientReady(GoogleApiClient apiClient, Observer<? super Location> observer) {
-        observer.onNext(LocationServices.FusedLocationApi.getLastLocation(apiClient));
+        Location location = LocationServices.FusedLocationApi.getLastLocation(apiClient);
+        if (location != null) {
+            observer.onNext(location);
+        }
         observer.onCompleted();
     }
 }


### PR DESCRIPTION
When location services are unavailable LastKnownLocationObservable emits null.

As [documentation](https://github.com/ReactiveX/RxJava/wiki/Implementing-Your-Own-Operators#other-considerations) says:

- Be aware that “null” is a valid item that may be emitted by an Observable. A frequent source of bugs is to test some variable meant to hold an emitted item against null as a substitute for testing whether or not an item was emitted. An emission of “null” is still an emission and is not the same as not emitting anything.

Null check fixes this making LastKnownLocationObservable support RxJava operators: `isEmpty`, `defaultIfEmpty`, `switchIfEmpty` etc.