### PR TITLE
Correct geocode to reverse geocode. Add new GeocodeObservable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,17 +94,31 @@ Subscription subscription = locationProvider.getDetectedActivity(0) // detection
     });
 ```
 
-### Geocode location
+### Reverse geocode location
 
 Do you need address for location?
 
 ```java
-Observable<List<Address>> geocodeObservable = locationProvider
-    .getGeocodeObservable(location.getLatitude(), location.getLongitude(), MAX_ADDRESSES);
+Observable<List<Address>> reverseGeocodeObservable = locationProvider
+    .getReverseGeocodeObservable(location.getLatitude(), location.getLongitude(), MAX_ADDRESSES);
 
-geocodeObservable
+reverseGeocodeObservable
     .subscribeOn(Schedulers.io())               // use I/O thread to query for addresses
     .observeOn(AndroidSchedulers.mainThread())  // return result in main android thread to manipulate UI
+    .subscribe(...);
+```
+
+### Geocode location
+
+Do you need address for a text search query?
+
+```java
+Observable<List<Address>> geocodeObservable = locationProvider
+    .getGeocodeObservable(String userQuery, MAX_ADDRESSES);
+
+geocodeObservable
+    .subscribeOn(Schedulers.io())
+    .observeOn(AndroidSchedulers.mainThread())
     .subscribe(...);
 ```
 

--- a/android-reactive-location/src/main/java/pl/charmas/android/reactivelocation/ReactiveLocationProvider.java
+++ b/android-reactive-location/src/main/java/pl/charmas/android/reactivelocation/ReactiveLocationProvider.java
@@ -28,7 +28,8 @@ import java.util.List;
 import pl.charmas.android.reactivelocation.observables.GoogleAPIClientObservable;
 import pl.charmas.android.reactivelocation.observables.PendingResultObservable;
 import pl.charmas.android.reactivelocation.observables.activity.ActivityUpdatesObservable;
-import pl.charmas.android.reactivelocation.observables.geocode.GeodecodeObservable;
+import pl.charmas.android.reactivelocation.observables.geocode.GeocodeObservable;
+import pl.charmas.android.reactivelocation.observables.geocode.ReverseGeocodeObservable;
 import pl.charmas.android.reactivelocation.observables.geofence.AddGeofenceObservable;
 import pl.charmas.android.reactivelocation.observables.geofence.AddGeofenceResult;
 import pl.charmas.android.reactivelocation.observables.geofence.RemoveGeofenceObservable;
@@ -83,7 +84,7 @@ public class ReactiveLocationProvider {
     }
 
     /**
-     * Creates obserbable that translates latitude and longitude to list of possible addresses using
+     * Creates observable that translates latitude and longitude to list of possible addresses using
      * included Geocoder class. You should subscribe for this observable on I/O thread.
      * The stream finishes after address list is available.
      *
@@ -92,8 +93,39 @@ public class ReactiveLocationProvider {
      * @param maxResults maximal number of results you are interested in
      * @return observable that serves list of address based on location
      */
-    public Observable<List<Address>> getGeocodeObservable(double lat, double lng, int maxResults) {
-        return GeodecodeObservable.createObservable(ctx, lat, lng, maxResults);
+    public Observable<List<Address>> getReverseGeocodeObservable(double lat, double lng, int maxResults) {
+        return ReverseGeocodeObservable.createObservable(ctx, lat, lng, maxResults);
+    }
+
+    /**
+     * Creates observable that translates a street address or other description into a list of
+     * possible addresses using included Geocoder class. You should subscribe for this
+     * observable on I/O thread.
+     * The stream finishes after address list is available.
+     *
+     * @param locationName a user-supplied description of a location
+     * @param maxResults max number of results you are interested in
+     * @return observable that serves list of address based on location name
+     */
+    public Observable<List<Address>> getGeocodeObservable(String locationName, int maxResults) {
+        return getGeocodeObservable(locationName, maxResults, null);
+    }
+
+    /**
+     * Creates observable that translates a street address or other description into a list of
+     * possible addresses using included Geocoder class. You should subscribe for this
+     * observable on I/O thread.
+     * The stream finishes after address list is available.
+     * <p/>
+     * You may specify a bounding box for the search results.
+     *
+     * @param locationName a user-supplied description of a location
+     * @param maxResults max number of results you are interested in
+     * @param bounds restricts the results to geographical bounds. May be null
+     * @return observable that serves list of address based on location name
+     */
+    public Observable<List<Address>> getGeocodeObservable(String locationName, int maxResults, LatLngBounds bounds) {
+        return GeocodeObservable.createObservable(ctx, locationName, maxResults, bounds);
     }
 
     /**

--- a/android-reactive-location/src/main/java/pl/charmas/android/reactivelocation/observables/geocode/GeocodeObservable.java
+++ b/android-reactive-location/src/main/java/pl/charmas/android/reactivelocation/observables/geocode/GeocodeObservable.java
@@ -1,0 +1,54 @@
+package pl.charmas.android.reactivelocation.observables.geocode;
+
+import android.content.Context;
+import android.location.Address;
+import android.location.Geocoder;
+
+import com.google.android.gms.maps.model.LatLngBounds;
+
+import java.io.IOException;
+import java.util.List;
+
+import rx.Observable;
+import rx.Subscriber;
+
+public class GeocodeObservable implements Observable.OnSubscribe<List<Address>> {
+    private final Context ctx;
+    private final String locationName;
+    private final int maxResults;
+    private final LatLngBounds bounds;
+
+    public static Observable<List<Address>> createObservable(Context ctx, String locationName, int maxResults, LatLngBounds bounds) {
+        return Observable.create(new GeocodeObservable(ctx, locationName, maxResults, bounds));
+    }
+
+    private GeocodeObservable(Context ctx, String locationName, int maxResults, LatLngBounds bounds) {
+        this.ctx = ctx;
+        this.locationName = locationName;
+        this.maxResults = maxResults;
+        this.bounds = bounds;
+    }
+
+    @Override
+    public void call(Subscriber<? super List<Address>> subscriber) {
+        Geocoder geocoder = new Geocoder(ctx);
+        List<Address> result;
+
+        try {
+            if (bounds != null) {
+                result = geocoder.getFromLocationName(locationName, maxResults, bounds.southwest.latitude, bounds.southwest.longitude, bounds.northeast.latitude, bounds.northeast.longitude);
+            } else {
+                result = geocoder.getFromLocationName(locationName, maxResults);
+            }
+
+            if (!subscriber.isUnsubscribed()) {
+                subscriber.onNext(result);
+                subscriber.onCompleted();
+            }
+        } catch (IOException e) {
+            if (!subscriber.isUnsubscribed()) {
+                subscriber.onError(e);
+            }
+        }
+    }
+}

--- a/android-reactive-location/src/main/java/pl/charmas/android/reactivelocation/observables/geocode/ReverseGeocodeObservable.java
+++ b/android-reactive-location/src/main/java/pl/charmas/android/reactivelocation/observables/geocode/ReverseGeocodeObservable.java
@@ -10,17 +10,17 @@ import java.util.List;
 import rx.Observable;
 import rx.Subscriber;
 
-public class GeodecodeObservable implements Observable.OnSubscribe<List<Address>> {
+public class ReverseGeocodeObservable implements Observable.OnSubscribe<List<Address>> {
     private final Context ctx;
     private final double latitude;
     private final double longitude;
     private final int maxResults;
 
     public static Observable<List<Address>> createObservable(Context ctx, double latitude, double longitude, int maxResults) {
-        return Observable.create(new GeodecodeObservable(ctx, latitude, longitude, maxResults));
+        return Observable.create(new ReverseGeocodeObservable(ctx, latitude, longitude, maxResults));
     }
 
-    private GeodecodeObservable(Context ctx, double latitude, double longitude, int maxResults) {
+    private ReverseGeocodeObservable(Context ctx, double latitude, double longitude, int maxResults) {
         this.ctx = ctx;
         this.latitude = latitude;
         this.longitude = longitude;

--- a/sample/src/main/java/pl/charmas/android/reactivelocation/sample/MainActivity.java
+++ b/sample/src/main/java/pl/charmas/android/reactivelocation/sample/MainActivity.java
@@ -104,7 +104,7 @@ public class MainActivity extends ActionBarActivity {
                 .flatMap(new Func1<Location, Observable<List<Address>>>() {
                     @Override
                     public Observable<List<Address>> call(Location location) {
-                        return locationProvider.getGeocodeObservable(location.getLatitude(), location.getLongitude(), 1);
+                        return locationProvider.getReverseGeocodeObservable(location.getLatitude(), location.getLongitude(), 1);
                     }
                 })
                 .map(new Func1<List<Address>, Address>() {


### PR DESCRIPTION
According to the `Geocoder` class docs...

> Geocoding is the process of transforming a street address or other description of a location into a (latitude, longitude) coordinate. Reverse geocoding is the process of transforming a (latitude, longitude) coordinate into a (partial) address.

This pull request renames the current `GeocodeObservable` to `ReverseGeocodeObservable`, and introduces a new `GeocodeObservable` that returns `Address`es from a string.