### PR TITLE
Added onActivityResult and removed the "never" option from location enabler option

### DIFF
--- a/sample/src/main/java/pl/charmas/android/reactivelocation/sample/MainActivity.java
+++ b/sample/src/main/java/pl/charmas/android/reactivelocation/sample/MainActivity.java
@@ -1,5 +1,6 @@
 package pl.charmas.android.reactivelocation.sample;
 
+import android.app.Activity;
 import android.content.Intent;
 import android.content.IntentSender;
 import android.location.Address;
@@ -18,6 +19,7 @@ import com.google.android.gms.location.ActivityRecognitionResult;
 import com.google.android.gms.location.LocationRequest;
 import com.google.android.gms.location.LocationSettingsRequest;
 import com.google.android.gms.location.LocationSettingsResult;
+import com.google.android.gms.location.LocationSettingsStates;
 import com.google.android.gms.location.LocationSettingsStatusCodes;
 
 import java.util.List;
@@ -78,6 +80,7 @@ public class MainActivity extends ActionBarActivity {
                 .checkLocationSettings(
                         new LocationSettingsRequest.Builder()
                                 .addLocationRequest(locationRequest)
+                                .setAlwaysShow(true)  //Refrence: http://stackoverflow.com/questions/29824408/google-play-services-locationservices-api-new-option-never
                                 .build()
                 )
                 .doOnNext(new Action1<LocationSettingsResult>() {
@@ -195,4 +198,27 @@ public class MainActivity extends ActionBarActivity {
             Log.d("MainActivity", "Error occurred", throwable);
         }
     }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        final LocationSettingsStates states = LocationSettingsStates.fromIntent(data);//intent);
+        switch (requestCode) {
+            case REQUEST_CHECK_SETTINGS:
+                //Refrence: https://developers.google.com/android/reference/com/google/android/gms/location/SettingsApi
+                switch (resultCode) {
+                    case RESULT_OK:
+                        // All required changes were successfully made
+                        Log.d("yoyo","OKAY");
+                        break;
+                    case RESULT_CANCELED:
+                        // The user was asked to change settings, but chose not to
+                       Log.d("yoyo","CANCELLED");
+                        break;
+                    default:
+                        break;
+                }
+                break;
+        }
+    }
+
 }

--- a/sample/src/main/java/pl/charmas/android/reactivelocation/sample/MainActivity.java
+++ b/sample/src/main/java/pl/charmas/android/reactivelocation/sample/MainActivity.java
@@ -41,7 +41,7 @@ import static rx.android.app.AppObservable.bindActivity;
 
 public class MainActivity extends ActionBarActivity {
     private static final int REQUEST_CHECK_SETTINGS = 0;
-
+    private final String TAG = getClass().getSimpleName();
     private ReactiveLocationProvider locationProvider;
 
     private TextView lastKnownLocationView;
@@ -208,11 +208,11 @@ public class MainActivity extends ActionBarActivity {
                 switch (resultCode) {
                     case RESULT_OK:
                         // All required changes were successfully made
-                        Log.d("yoyo","OKAY");
+                        Log.d(TAG,"User enabled location");
                         break;
                     case RESULT_CANCELED:
                         // The user was asked to change settings, but chose not to
-                       Log.d("yoyo","CANCELLED");
+                       Log.d(TAG,"User Cancelled enabling location");
                         break;
                     default:
                         break;


### PR DESCRIPTION
Added onActivityResult so that if the user chooses No or Never or doesnt enable the location then the code can know and take action appropriately

Added .setAlwaysShow(true) so that option of NEVER is removed when the user is asked to enable location. If the user clicks NEVER then he would have to reinstall the app to enbale location
or reset his request manually

Note: Closed the last pull request as it had internal comments being commited