### PR TITLE
Upgrade Play services to 8.1.0

### DIFF
--- a/android-reactive-location/build.gradle
+++ b/android-reactive-location/build.gradle
@@ -19,7 +19,7 @@ android {
 //TODO: local maven deployment
 
 dependencies {
-    compile 'com.google.android.gms:play-services-location:7.5.0'
+    compile 'com.google.android.gms:play-services-location:8.1.0'
     compile 'io.reactivex:rxjava:1.0.13'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,14 +5,14 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.3'
+        classpath 'com.android.tools.build:gradle:1.3.1'
     }
 }
 
 // To avoid manually setting the same values in all Android modules, set the value on the root
 // project and then reference this from the modules
 ext {
-    compileSdkVersion = 22
+    compileSdkVersion = 23
     buildToolsVersion = "22.0.1"
 }
 


### PR DESCRIPTION
With play-services-8.1.0 the library crashes due to breaking changes in 8.1.0
```
GoogleApiClient, PendingResult, and OptionalPendingResult are now abstract classes instead of interfaces. The signature of PendingResult.setResultCallback has changed from setResultCallback(ResultCallback<R> callback) to setResultCallback(ResultCallback<? super R> callback). An equivalent change has been made to setResultCallback that accepts a timeout parameter. If you were directly implementing these interfaces before, you’ll need to extend the abstract classes instead. If you used these classes for testing purposes, we recommend using the provided utility class PendingResults which can provide a Result that is either canceled or immediately available.
```
https://developers.google.com/android/guides/releases